### PR TITLE
[미션 4] permission UI 개선 및 코루틴으로 이미지 불러오기 구현

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,9 +20,6 @@
             android:exported="false" />
         <activity
             android:name=".view.PermissionActivity"
-            android:exported="false" />
-        <activity
-            android:name=".view.MainActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -30,6 +27,10 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".view.MainActivity"
+            android:exported="false" />
+
     </application>
 
 

--- a/app/src/main/java/com/example/app/DoodleAdapter.kt
+++ b/app/src/main/java/com/example/app/DoodleAdapter.kt
@@ -1,31 +1,43 @@
 package com.example.app
 
-import android.graphics.Bitmap
-import android.graphics.Color
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
+import android.widget.ProgressBar
 import androidx.recyclerview.widget.ListAdapter
-
 import androidx.recyclerview.widget.RecyclerView
 import com.example.app.data.JsonImage
 import kotlinx.coroutines.*
 
-class DoodleAdapter:
+class DoodleAdapter :
     ListAdapter<JsonImage, DoodleAdapter.DoodleAdapterViewHolder>(ImageDiffCallback) {
 
     inner class DoodleAdapterViewHolder(view: View) : RecyclerView.ViewHolder(view) {
-        val doodleImageView: ImageView = view.findViewById(R.id.doodle_item_view)
+
+        private val doodleImageView: ImageView = view.findViewById(R.id.doodle_item_view)
+        private val doodleProgressBar: ProgressBar = view.findViewById(R.id.doodle_progressbar)
+        private var doodleImage: JsonImage? = null
+
+        fun bind(doodleImage: JsonImage) {
+            this.doodleImage = doodleImage
+            doodleProgressBar.visibility = View.INVISIBLE
+            doodleImageView.setImageBitmap(doodleImage.image)
+        }
+
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): DoodleAdapterViewHolder {
-        val view = LayoutInflater.from(parent.context).inflate(R.layout.doodle_view_item, parent, false)
+        val view =
+            LayoutInflater.from(parent.context).inflate(R.layout.doodle_view_item, parent, false)
         return DoodleAdapterViewHolder(view)
     }
 
     override fun onBindViewHolder(holder: DoodleAdapterViewHolder, position: Int) {
-        holder.doodleImageView.setImageBitmap(getItem(position).image)
+        CoroutineScope(Dispatchers.Main).launch {
+            holder.bind(getItem(position))
+            println("$position")
+        }
     }
 
 }

--- a/app/src/main/java/com/example/app/view/DoodleActivity.kt
+++ b/app/src/main/java/com/example/app/view/DoodleActivity.kt
@@ -1,6 +1,5 @@
 package com.example.app.view
 
-import android.graphics.Bitmap
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import androidx.recyclerview.widget.GridLayoutManager
@@ -9,7 +8,6 @@ import com.example.app.DoodleAdapter
 import com.example.app.DoodleImageDownloader
 import com.example.app.R
 import com.example.app.data.JsonImage
-import org.json.JSONObject
 
 class DoodleActivity : AppCompatActivity() {
 
@@ -29,7 +27,7 @@ class DoodleActivity : AppCompatActivity() {
 
     private fun extractDataFromJson(adapter: DoodleAdapter) {
         val assetLoader = AssetLoader()
-        val imageData = assetLoader.getJsonString(this, "Image.json")
+        val imageData = assetLoader.getJsonString(this, "Image.json") ?: ""
         val doodleImageDownloader = DoodleImageDownloader()
         doodleImageDownloader.getDownloadedImages(jsonImageList, imageData, adapter)
     }

--- a/app/src/main/java/com/example/app/view/PermissionActivity.kt
+++ b/app/src/main/java/com/example/app/view/PermissionActivity.kt
@@ -10,8 +10,11 @@ import android.os.Bundle
 import android.provider.Settings
 import android.view.View
 import android.widget.Button
+import android.widget.LinearLayout
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.RequiresApi
+import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.constraintlayout.widget.ConstraintSet
 import androidx.core.content.ContextCompat
 import com.example.app.R
 import com.google.android.material.snackbar.Snackbar
@@ -19,17 +22,24 @@ import com.google.android.material.snackbar.Snackbar
 class PermissionActivity : AppCompatActivity() {
 
     private lateinit var imageLoadingButton: Button
+
+    @RequiresApi(Build.VERSION_CODES.M)
     private val permissionLauncher = requestPermissionLauncher()
-    private val permissionLauncherForSecond = requestPermissionLauncherSecond()
 
     @RequiresApi(Build.VERSION_CODES.M)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_permission)
 
+        if (haveMediaPermission()) {
+            goToMainActivity()
+        }
+        val permissionLayout: ConstraintLayout = findViewById(R.id.permission_layout)
+        permissionLayout.visibility = View.VISIBLE
+
         imageLoadingButton = findViewById(R.id.album_btn)
         imageLoadingButton.setOnClickListener {
-            loadImageFromContent()
+            permissionLauncher.launch("android.permission.READ_EXTERNAL_STORAGE")
         }
     }
 
@@ -37,75 +47,41 @@ class PermissionActivity : AppCompatActivity() {
         registerForActivityResult(
             ActivityResultContracts.RequestPermission()
         ) { isGranted: Boolean ->
-            if (isGranted) {
-                val loadImage = Intent(Intent.ACTION_GET_CONTENT).apply {
-                    this.type = "image/*"
-                }
-                startActivity(loadImage)
-            } else {
-                Snackbar.make(imageLoadingButton, "request denied", Snackbar.LENGTH_LONG).show()
-            }
-        }
-
-    private fun requestPermissionLauncherSecond() =
-        registerForActivityResult(
-            ActivityResultContracts.RequestPermission()
-        ) { isGranted: Boolean ->
-            if (isGranted) {
-                val loadImage = Intent(Intent.ACTION_GET_CONTENT).apply {
-                    this.type = "image/*"
-                }
-                startActivity(loadImage)
-            } else {
-                imageLoadingButton.showSnackbar(
-                    "이미지를 불러오기 위해 권한을 승인하시기 바랍니다",
-                    Snackbar.LENGTH_SHORT,
-                    "설정창"
-                ) {
-                    val settingIntent = Intent().apply {
-                        this.action = Settings.ACTION_APPLICATION_DETAILS_SETTINGS
-                        this.data = Uri.fromParts("package", packageName, null)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                when {
+                    isGranted -> {
+                        goToMainActivity()
                     }
-                    startActivity(settingIntent)
+                    shouldShowRequestPermissionRationale(Manifest.permission.READ_EXTERNAL_STORAGE) -> {
+                        Snackbar.make(
+                            imageLoadingButton,
+                            "앱을 실행하기 위해서는 권한을 승인하시기 바랍니다.",
+                            Snackbar.LENGTH_LONG
+                        ).show()
+                    }
+                    else -> {
+                        goToSettings()
+                    }
                 }
             }
         }
 
-    @RequiresApi(Build.VERSION_CODES.M)
-    private fun loadImageFromContent() {
-        if (ContextCompat.checkSelfPermission(
-                this,
-                Manifest.permission.ACCESS_MEDIA_LOCATION
-            ) == PackageManager.PERMISSION_GRANTED
-        ) {
-            Snackbar.make(imageLoadingButton, "permission Granted", Snackbar.LENGTH_LONG).show()
-            permissionLauncher.launch("android.permission.READ_EXTERNAL_STORAGE")
-        } else {
-            requestMediaPermission()
+    private fun goToMainActivity() {
+        val loadImage = Intent(this, MainActivity::class.java)
+        startActivity(loadImage)
+    }
+
+    private fun haveMediaPermission() = ContextCompat.checkSelfPermission(
+        this,
+        Manifest.permission.READ_EXTERNAL_STORAGE
+    ) == PackageManager.PERMISSION_GRANTED
+
+    private fun goToSettings() {
+        val settingIntent = Intent().apply {
+            this.action = Settings.ACTION_APPLICATION_DETAILS_SETTINGS
+            this.data = Uri.fromParts("package", packageName, null)
         }
+        startActivity(settingIntent)
     }
 
-    @RequiresApi(Build.VERSION_CODES.M)
-    private fun requestMediaPermission() {
-        if (shouldShowRequestPermissionRationale(Manifest.permission.READ_EXTERNAL_STORAGE)) {
-            permissionLauncherForSecond.launch("android.permission.READ_EXTERNAL_STORAGE")
-        } else {
-            permissionLauncher.launch("android.permission.READ_EXTERNAL_STORAGE")
-        }
-    }
-
-}
-
-fun View.showSnackbar(
-    msg: String,
-    length: Int,
-    actionMessage: CharSequence?,
-    action: (View) -> Unit
-) {
-    val snackbar = Snackbar.make(this, msg, length)
-    if (actionMessage != null) {
-        snackbar.setAction(actionMessage) {
-            action(this)
-        }.show()
-    }
 }

--- a/app/src/main/java/com/example/app/view/PermissionActivity.kt
+++ b/app/src/main/java/com/example/app/view/PermissionActivity.kt
@@ -30,12 +30,13 @@ class PermissionActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_permission)
+        val permissionLayout: ConstraintLayout = findViewById(R.id.permission_layout)
 
         if (haveMediaPermission()) {
             goToMainActivity()
+        } else {
+            permissionLayout.visibility = View.VISIBLE
         }
-        val permissionLayout: ConstraintLayout = findViewById(R.id.permission_layout)
-        permissionLayout.visibility = View.VISIBLE
 
         imageLoadingButton = findViewById(R.id.album_btn)
         imageLoadingButton.setOnClickListener {

--- a/app/src/main/res/layout/activity_permission.xml
+++ b/app/src/main/res/layout/activity_permission.xml
@@ -4,6 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:id="@+id/permission_layout"
+    android:visibility="gone"
     tools:context=".view.MainActivity">
 
     <ImageView

--- a/app/src/main/res/layout/doodle_view_item.xml
+++ b/app/src/main/res/layout/doodle_view_item.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    android:layout_height="wrap_content">
 
     <ImageView
         android:id="@+id/doodle_item_view"
@@ -10,6 +10,15 @@
         android:layout_height="0dp"
         android:scaleType="fitXY"
         app:layout_constraintDimensionRatio="1:1"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <ProgressBar
+        android:id="@+id/doodle_progressbar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 


### PR DESCRIPTION
- 코루틴을 통해 새 화면으로 전환해서 한꺼번에 이미지를 보이지 않고 기다리면 다운로드되는 이미지가 순차적으로 표시되는 기능 구현
  - Dispatchers.IO는 네트워크 입출력을 할 때
  - Dispatchers.Default는 데이터를 수정할 때
  - Dispatchers.Main은 UI를 갱신할 때 사용함

- Permission UI 개선
  - 첫 화면을 Permission을 얻을 수 있도록 개선
  - 권한이 있으면 바로 갤러리 앱 화면으로 이동
  - 없으면 설정창으로 갈 수 있도록 성능 개선